### PR TITLE
fix: Wrap default values in () as required.

### DIFF
--- a/lib/active_record/connection_adapters/spanner/schema_creation.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_creation.rb
@@ -129,7 +129,7 @@ module ActiveRecord
             sql << " NOT NULL"
           end
           if options.key? :default
-            sql << " DEFAULT #{quote_default_expression options[:default], column}"
+            sql << " DEFAULT (#{quote_default_expression options[:default], column})"
           end
 
           if !options[:allow_commit_timestamp].nil? &&

--- a/lib/active_record/type/spanner/time.rb
+++ b/lib/active_record/type/spanner/time.rb
@@ -9,7 +9,7 @@
 module ActiveRecord
   module Type
     module Spanner
-      class Time < ActiveRecord::Type::Time
+      class Time < ActiveRecord::Type::DateTime
         def serialize_with_isolation_level value, isolation_level
           if value == :commit_timestamp
             return "PENDING_COMMIT_TIMESTAMP()" if isolation_level == :dml

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -1025,7 +1025,7 @@ module TestMigrationsWithMockServer
       assert_equal 1, ddl_requests[2].statements.length
 
       expectedDdl = "CREATE TABLE `singers` "
-      expectedDdl << "(`id` INT64 NOT NULL, `name` STRING(MAX) NOT NULL DEFAULT 'no name', `age` INT64 NOT NULL DEFAULT 0) "
+      expectedDdl << "(`id` INT64 NOT NULL, `name` STRING(MAX) NOT NULL DEFAULT ('no name'), `age` INT64 NOT NULL DEFAULT (0)) "
       expectedDdl << "PRIMARY KEY (`id`)"
       assert_equal expectedDdl, ddl_requests[2].statements[0]
     end


### PR DESCRIPTION
Fix not merged upstream, merging into our fork for now https://github.com/googleapis/ruby-spanner-activerecord/pull/238