### PR TITLE
Spanner timestamp maps better to DateTime than Time

### DIFF
--- a/lib/active_record/type/spanner/time.rb
+++ b/lib/active_record/type/spanner/time.rb
@@ -9,7 +9,7 @@
 module ActiveRecord
   module Type
     module Spanner
-      class Time < ActiveRecord::Type::Time
+      class Time < ActiveRecord::Type::DateTime
         def serialize_with_isolation_level value, isolation_level
           if value == :commit_timestamp
             return "PENDING_COMMIT_TIMESTAMP()" if isolation_level == :dml


### PR DESCRIPTION
Waiting to merge upstream here https://github.com/googleapis/ruby-spanner-activerecord/pull/239

Extending ActiveRecord::Type::Time means that string values get incorrectly coerced to have a date of 2000-01-01. See https://github.com/rails/rails/blob/main/activemodel/lib/active_model/type/time.rb#L14. This is because Time in activerecord is intended to store just the time value (and maps to a TIME type in other databases), unlike Time generally in ruby that represents a date and time.